### PR TITLE
fix: 랭킹 api 오류 수정 feature/#64

### DIFF
--- a/backend/styles/views.py
+++ b/backend/styles/views.py
@@ -22,7 +22,9 @@ class ShowStyleView(APIView):
         try:
             gender = request.GET.get('gender')
             res = cache.get(gender)
-            if res == 'except':
+            if not res:
+                return JsonResponse(get_ranking(gender),status=status.HTTP_200_OK)
+            elif res == 'except':
                 raise Exception
             return JsonResponse(res,status=status.HTTP_200_OK)
         except:


### PR DESCRIPTION
## 추가한 기능 설명
캐시에 없으면 랭킹 계산해서 반환
<br>
http://localhost/
## check list
처음 접속했을때 랭킹 api 반환이 200번인지

- [O] issue number를 브랜치 앞에 추가 하였는가?
- [O] 모든 단위 테스트를 돌려보고 기존에 작동하던 테스트에 영향이 없는 것을 확인했는가?
